### PR TITLE
fix: stream format must be set to mpeg rather than mp3

### DIFF
--- a/goicy.ini
+++ b/goicy.ini
@@ -28,7 +28,7 @@ connectionattempts = 5
 streamtype = ffmpeg
 
 ; stream format
-; mp3 or aac
+; mpeg or aac
 format = aac
 
 ; stream name


### PR DESCRIPTION
Very minor type in the example config. If you would like to stream using mpeg the string `mpeg` must be added for the format otherwise `aac` would be the default 